### PR TITLE
Reset streak if a day was missed

### DIFF
--- a/utilities/accountability.py
+++ b/utilities/accountability.py
@@ -75,8 +75,10 @@ class AccountabilityCog(commands.Cog):
 
                 # Update Srteak And NovaCoins If User Logs Daily
                 if last_logged != today:
-                    if last_logged == today - timedelta(days=1):
-                        streak += 1
+                    if last_logged and (today - last_logged).days == 1:
+                        streak += 1  # Continue streak
+                    else:
+                        streak = 1  # Reset streak if a day was missed
 
                     # Calculate And Update NovaCoins
                     daily_bonus = int(10 * (0.02 * streak))


### PR DESCRIPTION
The issue is that current streak calculation **only checks if the last logged date is exactly one day before today** (`last_logged == today - timedelta(days=1)`).  

**Why is it incorrect?**  
- If the user **misses a day** (e.g., they logged on Feb 27 but missed Feb 28 and logged again on Mar 2), current code **doesn't reset the streak** when it should.  
- It only checks if the last log was **yesterday**, but doesn't account for gaps. 